### PR TITLE
fix: favicon link

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -47,7 +47,7 @@ export default function Layout({
         <title>{fullTitle}</title>
         <link
           rel="shortcut icon"
-          href="//www.gravatar.com/avatar/166e0b975c36bbe15caa65209940035c.png"
+          href="https://www.gravatar.com/avatar/166e0b975c36bbe15caa65209940035c.png"
         />
         <link
           rel="stylesheet"


### PR DESCRIPTION
Trying to fetch the favicon for a view in a feed reader.
But I am getting `https://www.tommoor.com//www.gravatar.com/avatar/166e0b975c36bbe15caa65209940035c.png`