### PR TITLE
Update homepage links: Twitter to X, Abstract to LinkedIn

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -27,8 +27,8 @@ export default function Navigation({ noHome }) {
           </Link>
         </li>
         <li>
-          <MenuItem href="https://www.twitter.com/tommoor" target="_blank">
-            Twitter
+          <MenuItem href="https://x.com/tommoor" target="_blank">
+            X
           </MenuItem>
         </li>
       </ul>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -21,12 +21,12 @@ export default function Home() {
             Linear
           </a>
           . Previously I was principal engineer at{" "}
-          <a href="https://www.abstract.com" target="_blank">
+          <a href="https://www.linkedin.com/company/abstract-app" target="_blank">
             Abstract
           </a>
           . Find me on{" "}
-          <a href="https://www.twitter.com/tommoor" target="_blank">
-            Twitter
+          <a href="https://x.com/tommoor" target="_blank">
+            X
           </a>
           , somewhere in NYC, or send a friendly{" "}
           <a href="mailto:tom.moor@gmail.com">Email</a>.


### PR DESCRIPTION
## Summary
- Rename "Twitter" to "X" and update URLs from twitter.com to x.com in the homepage and navigation
- Update the Abstract link to point to its LinkedIn company page since abstract.com is no longer active

🤖 Generated with [Claude Code](https://claude.com/claude-code)